### PR TITLE
Modified to support generating multiple independent noise series

### DIFF
--- a/colorednoise.py
+++ b/colorednoise.py
@@ -1,6 +1,6 @@
 """Generate colored noise."""
 
-from numpy import concatenate
+from numpy import concatenate, sqrt
 from numpy.fft import ifft, fftfreq
 from numpy.random import normal
 
@@ -96,6 +96,6 @@ def powerlaw_psd_gaussian(exponent, size, fmin=0):
                     axis=-1)
 
     # time series
-    y = ifft(s, axis=-1).real
+    y = ifft(s, axis=-1).real * size[-1]
 
-    return y / y.std(axis=-1)[...,None]
+    return y / sqrt((s_scale**2).sum())

--- a/colorednoise.py
+++ b/colorednoise.py
@@ -1,41 +1,44 @@
 """Generate colored noise."""
 
-from numpy import concatenate, real, std, abs
+from numpy import concatenate
 from numpy.fft import ifft, fftfreq
 from numpy.random import normal
 
-def powerlaw_psd_gaussian(exponent, samples, fmin=0):
+
+def powerlaw_psd_gaussian(exponent, size, fmin=0):
     """Gaussian (1/f)**beta noise.
-    
+
     Based on the algorithm in:
-    Timmer, J. and Koenig, M.: 
-    On generating power law noise. 
+    Timmer, J. and Koenig, M.:
+    On generating power law noise.
     Astron. Astrophys. 300, 707-710 (1995)
-    
+
     Normalised to unit variance
-    
+
     Parameters:
     -----------
-    
+
     exponent : float
         The power-spectrum of the generated noise is proportional to
-        
+
         S(f) = (1 / f)**beta
         flicker / pink noise:   exponent beta = 1
         brown noise:            exponent beta = 2
-        
-        Furthermore, the autocorrelation decays proportional to lag**-gamma 
+
+        Furthermore, the autocorrelation decays proportional to lag**-gamma
         with gamma = 1 - beta for 0 < beta < 1.
         There may be finite-size issues for beta close to one.
-    
-    samples : int
-        number of samples to generate
-    
+
+    shape : int or iterable
+        The output has the given shape, and the desired power spectrum in
+        the last coordinate. That is, the last dimension is taken as time,
+        and all other components are independent.
+
     fmin : float, optional
         Low-frequency cutoff.
         Default: 0 corresponds to original paper. It is not actually
         zero, but 1/samples.
-        
+
     Returns
     -------
     out : array
@@ -49,33 +52,50 @@ def powerlaw_psd_gaussian(exponent, samples, fmin=0):
     >>> import colorednoise as cn
     >>> y = cn.powerlaw_psd_gaussian(1, 5)
     """
-    
+
+    try:
+        size = list(size)
+    except TypeError:
+        size = [size]
+
+    samples = size[-1]
+
     # frequencies (we asume a sample rate of one)
     f = fftfreq(samples)
-    
-    # scaling factor for all frequencies 
-    ## though the fft for real signals is symmetric,
-    ## the array with the results is not - take neg. half!
+
+    # scaling factor for all frequencies
+    # though the fft for real signals is symmetric,
+    # the array with the results is not - take neg. half!
     s_scale = abs(concatenate([f[f<0], [f[-1]]]))
-    ## low frequency cutoff?!?
+
+    # Adjust the size so we only generate as many samples as needed.
+    size[-1] = len(s_scale)
+
+    # low frequency cutoff?!?
     if fmin:
-        ix = sum(s_scale>fmin)
+        ix = sum(s_scale > fmin)
         if ix < len(f):
             s_scale[ix:] = s_scale[ix]
     s_scale = s_scale**(-exponent/2.)
-    
+
+    # Change the shape of s_scale to broadcast correctly with
+    # the generated random values, by generating enough new axes.
+    dims_to_add = len(size) - 1
+    s_scale = s_scale[(None,)*dims_to_add + (Ellipsis,)]
+
     # scale random power + phase
-    sr = s_scale * normal(size=len(s_scale))
-    si = s_scale * normal(size=len(s_scale))
+    sr = s_scale * normal(size=size)
+    si = s_scale * normal(size=size)
     if not (samples % 2): si[0] = si[0].real
 
     s = sr + 1J * si
     # this is complicated... because for odd sample numbers,
-    ## there is one less positive freq than for even sample numbers
-    s = concatenate([s[1-(samples % 2):][::-1], s[:-1].conj()])
+    # there is one less positive freq than for even sample numbers
+    s = concatenate((s[...,1-(samples % 2):][...,::-1],
+                     s[...,:-1].conj()),
+                    axis=-1)
 
     # time series
-    y = ifft(s).real
+    y = ifft(s, axis=-1).real
 
-    return y / std(y)
-
+    return y / y.std(axis=-1)[...,None]

--- a/tests/test_powerlaw_psd_gaussian.py
+++ b/tests/test_powerlaw_psd_gaussian.py
@@ -2,11 +2,16 @@ import unittest
 import numpy as np
 import colorednoise as cn
 
+
 class TestPowerlawPsdGaussian(unittest.TestCase):
     # these only test very basic functioning as of yet
-    def test_powerlaw_psd_gaussian_output_shape(self):
+    def test_powerlaw_psd_gaussian_scalar_output_shape(self):
         n = cn.powerlaw_psd_gaussian(1, 16)
         self.assertEqual(n.shape, (16,))
+
+    def test_powerlaw_psd_gaussian_vector_output_shape(self):
+        n = cn.powerlaw_psd_gaussian(1, (100,5))
+        self.assertEqual(n.shape, (100,5))
 
     def test_powerlaw_psd_gaussian_output_finite(self):
         n = cn.powerlaw_psd_gaussian(1, 16, fmin=0.1)


### PR DESCRIPTION
I needed to generate many sequences of pink noise at once, so I vectorized your function. Here's an example and a plot of PSD.

```python3
from scipy import signal
import colorednoise as cn
pinks = cn.powerlaw_psd_gaussian(exponent=1, size=(1000,2001), fmin=0.05)
freqs, psd = signal.welch(pinks)

plt.figure(figsize=(5, 4))
plt.loglog(freqs, psd.T, alpha=0.5)
```

![pink-noise](https://user-images.githubusercontent.com/15931271/51292333-34651b00-19bf-11e9-9aef-d3dc58963ab3.png)
