### PR TITLE
Fix magnitude of frequencies

### DIFF
--- a/colorednoise.py
+++ b/colorednoise.py
@@ -115,10 +115,13 @@ def powerlaw_psd_gaussian(exponent, size, fmin=0, random_state=None):
     
     # If the signal length is even, frequencies +/- 0.5 are equal
     # so the coefficient must be real.
-    if not (samples % 2): si[...,-1] = 0
+    if not (samples % 2):
+        si[..., -1] = 0
+        sr[..., -1] *= sqrt(2)    # Fix magnitude
     
     # Regardless of signal length, the DC component must be real
-    si[...,0] = 0
+    si[..., 0] = 0
+    sr[..., 0] *= sqrt(2)    # Fix magnitude
     
     # Combine power + corrected phase to Fourier components
     s  = sr + 1J * si


### PR DESCRIPTION
Hi, I noticed a problem with the noise signals generated by this module. I am using the colored noise signals to generate random walks by integrating them (i.e. `signal.cumsum(-1)`). When looking at the average absolute value over many such random walks (i.e. the expected "distance to the origin"), these random walks did not behave as expected. In the figure, I have plotted this average distance for the case of integrated white noise (exponent = 0).

![Unknown-1](https://user-images.githubusercontent.com/21868012/167161467-c77db1b4-32d4-4c5e-9a40-e9fa3485825e.png)

As can be seen, the colored noise from this module ("colorednoise original") does not behave as expected ("scipy" just means generating white noise by independently sampling gaussian noise). This sort of curve is only possible if the white noise signal is correlated over time, which, by definition, it shouldn't be. After comparing the implemented algorithm with the source (Timmer and Koenig), I found an implementation detail which isn't really mentioned in the source: How to make sure the imaginary part is 0 at the DC frequency (and optionally at the highest frequency). In your implementation, you simply set `si` to 0 here, but this changes the magnitude of the signal at these points. As a fix, I multiplied the real part `sr` by sqrt(2), such that the magnitude is, on average, unchanged (as `si` and `sr` have the same magnitude in expectation at every frequency). The result is plotted in the figure and lines up with the expected curve.

Of course, this will also change things for other exponents, but I can't think of an interpretation of those changes. In most cases it probably makes little difference, but in my case, where I was integrating these signals, it does.