### PR TITLE
type-hint for `fmin` in `colorednoise.powerlaw_psd_gaussian`

### DIFF
--- a/colorednoise.py
+++ b/colorednoise.py
@@ -6,7 +6,7 @@ from numpy.random import default_rng, Generator, RandomState
 from numpy import sum as npsum
 
 
-def powerlaw_psd_gaussian(exponent, size, fmin=0, random_state=None):
+def powerlaw_psd_gaussian(exponent, size, fmin: float = 0.0, random_state=None):
     """Gaussian (1/f)**beta noise.
 
     Based on the algorithm in:


### PR DESCRIPTION
`pyright` was throwing an error for me in my calling code, because it thought `powerlaw_psd_gaussian` expected `fmin` to be an `int` (based on the `fmin=0` function signature). This updates `fmin` to explicitly be a float value, as noted in the docs.